### PR TITLE
Remove npm warning by changing urijs to lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "position": "center"
   },
   "dependencies": {
-    "URIjs": "1.x.x",
+    "urijs": "1.x.x",
     "adm-zip": "0.4.7",
     "airplay-js": "git+https://github.com/guerrerocarlos/node-airplay-js.git",
     "async": "0.9.0",


### PR DESCRIPTION
Full warning was
npm WARN deprecated URIjs@1.16.1: package renamed to "urijs" (lower-case), please update accordingly