### PR TITLE
Update require reference to add lowercase 'urijs'

### DIFF
--- a/src/app/global.js
+++ b/src/app/global.js
@@ -40,7 +40,7 @@ var
 
     // Web
     querystring = require('querystring'),
-    URI = require('URIjs'),
+    URI = require('urijs'),
 
     // Torrent engines
     peerflix = require('peerflix'),


### PR DESCRIPTION
This should fix the last comment on #57, where updating the reference to URIjs made the app fail. 

I was able to rebuild the app from scratch and browse the videos, but for all the movies I tried I got 
```
>> [26901:1027/170913:INFO:CONSOLE(1409)] ""VIDEOJS:" "ERROR:" "(CODE:4 MEDIA_ERR_SRC_NOT_SUPPORTED)" "The video could not be loaded, either because the server or network failed or because the format is not supported."", source: app://host/src/app/vendor/video.js/dist/video-js/video.dev.js (1409)
```

I have the feeling that this is related to the network I'm on, but I would like someone to verify that it doesn't break anything, I don't want to break more things :(